### PR TITLE
redesigning tmux system

### DIFF
--- a/meta/schema.json
+++ b/meta/schema.json
@@ -303,7 +303,7 @@
                             "steps",
                             "sections"
                           ],
-                          "description": "Layout mode: 'grid' for automatic 2x2 grid, 'manual' for custom splits, 'steps' for step-by-step creation, 'sections' for hierarchical sections"
+                          "description": "Layout mode: 'grid' for automatic 2x2 grid, 'manual' for custom splits, 'steps' for step-by-step creation, 'sections' for hierarchical sections with nested items"
                         },
                         {
                           "type": "object",
@@ -353,6 +353,46 @@
                     },
                     "section": {
                       "$ref": "#/$defs/tmuxSection"
+                    },
+                    "paneDefinitions": {
+                      "type": "object",
+                      "description": "Pane definitions for steps layout mode",
+                      "additionalProperties": {
+                        "$ref": "#/$defs/tmuxPane"
+                      }
+                    },
+                    "steps": {
+                      "type": "array",
+                      "description": "Step-by-step instructions for creating the layout",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "action": {
+                            "type": "string",
+                            "enum": ["split"],
+                            "description": "Action to perform"
+                          },
+                          "target": {
+                            "type": "string",
+                            "description": "Name of the pane to split from"
+                          },
+                          "direction": {
+                            "type": "string",
+                            "enum": ["horizontal", "vertical"],
+                            "description": "Direction to split"
+                          },
+                          "size": {
+                            "type": "string",
+                            "pattern": "^[0-9]+%?$",
+                            "description": "Size of the new pane"
+                          },
+                          "newPane": {
+                            "type": "string",
+                            "description": "Name of the new pane to create"
+                          }
+                        },
+                        "required": ["action", "target", "direction", "newPane"]
+                      }
                     },
                     "panes": {
                       "type": "array",
@@ -416,8 +456,85 @@
                     }
                   },
                   "required": [
-                    "name",
-                    "panes"
+                    "name"
+                  ],
+                  "allOf": [
+                    {
+                      "anyOf": [
+                        {
+                          "required": ["panes"]
+                        },
+                        {
+                          "required": ["section"]
+                        },
+                        {
+                          "allOf": [
+                            {
+                              "required": ["paneDefinitions"]
+                            },
+                            {
+                              "required": ["steps"]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "layout": {
+                            "const": "sections"
+                          }
+                        }
+                      },
+                      "then": {
+                        "required": ["section"],
+                        "not": {
+                          "anyOf": [
+                            {"required": ["panes"]},
+                            {"required": ["paneDefinitions"]},
+                            {"required": ["steps"]}
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "layout": {
+                            "const": "steps"
+                          }
+                        }
+                      },
+                      "then": {
+                        "required": ["paneDefinitions", "steps"],
+                        "not": {
+                          "anyOf": [
+                            {"required": ["panes"]},
+                            {"required": ["section"]}
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "if": {
+                        "properties": {
+                          "layout": {
+                            "enum": ["grid", "manual"]
+                          }
+                        }
+                      },
+                      "then": {
+                        "required": ["panes"],
+                        "not": {
+                          "anyOf": [
+                            {"required": ["section"]},
+                            {"required": ["paneDefinitions"]},
+                            {"required": ["steps"]}
+                          ]
+                        }
+                      }
+                    }
                   ]
                 }
               }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extend tmux window schema to support a "steps" layout with `paneDefinitions`/`steps`, and enforce layout-specific required fields and exclusivity.
> 
> - **Schema (meta/schema.json)**:
>   - **TMUX Window Layouts**:
>     - Add `steps` layout support with `paneDefinitions` (map of `tmuxPane`) and `steps` (array of split actions with `action`, `target`, `direction`, `size`, `newPane`).
>     - Update `layout` description for `sections` to note nested items.
>   - **Validation Rules**:
>     - Introduce conditional requirements and mutual exclusivity:
>       - `sections` layout: require `section` only; disallow `panes`, `paneDefinitions`, `steps`.
>       - `steps` layout: require `paneDefinitions` and `steps`; disallow `panes`, `section`.
>       - `grid`/`manual` layouts: require `panes`; disallow `section`, `paneDefinitions`, `steps`.
>     - Relax base `required` on windows from `name`+`panes` to `name` with layout-specific enforcement.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 034d32a496732dd8f6af6dd6ba48041406e7d013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->